### PR TITLE
Fix go version in go.mod to 1.25

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/CZERTAINLY/Seeker
 
-go 1.24.6
+go 1.25
 
 require (
 	github.com/CycloneDX/cyclonedx-go v0.9.2


### PR DESCRIPTION
Code uses features from 1.25, namely `t.Output()`